### PR TITLE
bug fix for clang-format not correctly recognizing additional arguments

### DIFF
--- a/hooks/clang-format
+++ b/hooks/clang-format
@@ -29,7 +29,7 @@ function parse_args {
 function clangformat_main {
 	check_installed "$CMD"
 	parse_args
-	diff_formatted "${args[@]}" "$filename"
+	diff_formatted "${args[*]}" "$filename"
 }
 
 clangformat_main

--- a/hooks/utils
+++ b/hooks/utils
@@ -68,8 +68,8 @@ function parse_ddash_args {
 function diff_formatted {
 	# Quoting $1 interferes with array creation
 	# shellcheck disable=SC2206
-	args=($1)
-	filename="$2"
+	local args=($1)
+	local filename="$2"
 	if [[ " ${args[*]} " == *" -i "* ]]; then
 		# Here, diff compares what the file is before and after transform
 		diff "$filename" <(clang-format "${args[@]}"; cat "$filename")

--- a/tests/hooks_test.py
+++ b/tests/hooks_test.py
@@ -86,7 +86,9 @@ Edit your pre-commit config or use a different version of clang-format
                         ["hooks/clang-format", "--style=google", "-i", tmp_ok.name]
                     )
                 except sp.CalledProcessError as e:
-                    print(e)
+                    print(e.output)
+                    raise e
+
                 with open(tmp_ok.name, "rb") as tmp_ok_i:
                     assert tmp_ok_i.read() == content_ok
 


### PR DESCRIPTION
Resolves #9 

According to this [post](https://linuxconfig.org/how-to-use-arrays-in-bash-script#h6-array-operations),

`* `and `@` behaves differently when doing string expansion,

> Both syntax let us access all the values of the array and produce the same results, unless the expansion it's quoted. In this case a difference arises: in the first case, when using @, the expansion will result in a word for each element of the array.

```
$ my_array=(foo bar)
# number of args are the same
$ for i in "${my_array[@]}"; do echo "$i"; done
foo
bar

# * will expand args in a list into 1 argument
$ for i in "${my_array[*]}"; do echo "$i"; done
foo bar
```

I have a script to verify this,

```bash
#!/usr/bin/env bash

arr=(a b c d)

echo "${#arr[*]}"

function count_args() {
  echo '$#' $#
  echo '$@' $@
  echo '$1' $1
  local my_arr=($1)
  echo 'construct ($1) as array, num of elements:' "${#my_arr[@]}"
  echo 'my_arr ($1) is:' "${my_arr[@]}"
}

count_args "${arr[@]}"

count_args "${arr[*]}"
```

output,

```
(tc58) ➜  bash git:(master) bash array.sh
4
$# 4
$@ a b c d
$1 a
construct ($1) as array, num of elements: 1
my_arr ($1) is: a
$# 1
$@ a b c d
$1 a b c d
construct ($1) as array, num of elements: 4
my_arr ($1) is: a b c d
```