### PR TITLE
sha is deprecated

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ The above uses this `.pre-commit-config.yaml`:
 fail_fast: false
 repos:
   - repo: https://github.com/pocc/pre-commit-hooks
-    sha: master
+    rev: master
     hooks:
       - id: clang-format
         args: [--style=Google]


### PR DESCRIPTION
according to pre-commit official [doc](https://pre-commit.com/#pre-commit-configyaml---repos)

> the revision or tag to clone at. new in 1.7.0: previously sha