### PR TITLE
Check existence of -p argument correctly for clang-tidy and oclint

### DIFF
--- a/hooks/clang_tidy.py
+++ b/hooks/clang_tidy.py
@@ -19,7 +19,12 @@ class ClangTidyCmd(ClangAnalyzerCmd):
         self.edit_in_place = "-fix" in self.args or "--fix-errors" in self.args
         self.parse_ddash_args()
         # If a compilation database is not used, suppress errors
-        if "-p" not in self.args:
+        cdb_found = False
+        for arg in self.args:
+            if arg.startswith("-p"):
+                cdb_found = True
+                break
+        if not cdb_found:
             self.add_if_missing(["--", "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"])
         # Enable all of the checks
         self.add_if_missing(["-checks=*"])

--- a/hooks/oclint.py
+++ b/hooks/oclint.py
@@ -18,7 +18,12 @@ class OCLintCmd(ClangAnalyzerCmd):
         self.parse_args(args)
         self.parse_ddash_args()
         # If a compilation database is not used, suppress errors
-        if "-p" not in self.args:
+        cdb_found = False
+        for arg in self.args:
+            if arg.startswith("-p"):
+                cdb_found = True
+                break
+        if not cdb_found:
             self.add_if_missing(["--", "-DCMAKE_EXPORT_COMPILE_COMMANDS=ON"])
 
     def run(self):

--- a/tests/test_dashp.py
+++ b/tests/test_dashp.py
@@ -1,0 +1,33 @@
+"""Test oclint and clang-tidy -p argument"""
+from hooks.clang_tidy import ClangTidyCmd
+from hooks.oclint import OCLintCmd
+
+
+class TestHDashp:
+    """Deal with the conftest weirdness"""
+
+    @classmethod
+    def setup_class(cls):
+        """Setup the scenario list"""
+        cls.scenarios = [
+            ["ClangTidyCmd", {"klass": ClangTidyCmd}],
+            ["OCLintCmd", {"klass": OCLintCmd}],
+        ]
+
+    @staticmethod
+    def test_clang_tidy_dashp_present(klass) -> None:
+        """If -p is in arguments make sure -DCMAKE_EXPORT_COMPILE_COMMANDS is *not*"""
+        checker = klass(["-p=cmake-build-debug"])
+        for arg in checker.args:
+            assert not arg.startswith("-DCMAKE_EXPORT_COMPILE_COMMANDS")
+
+    @staticmethod
+    def test_clang_tidy_dash_notpresent(klass) -> None:
+        """If -p is *not* in arguments make sure -DCMAKE_EXPORT_COMPILE_COMMANDS is defined"""
+        checker = klass([])
+        export_found = False
+        for arg in checker.args:
+            if arg.startswith("-DCMAKE_EXPORT_COMPILE_COMMANDS"):
+                export_found = True
+                break
+        assert export_found


### PR DESCRIPTION
Fixes #15 