### PR TITLE
Allow formatting Java and Objective-C++ files with clang-format

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -6,30 +6,30 @@
 - id: clang-format
   name: clang-format
   entry: clang-format-hook
-  description: Formats C/CPP code
-  files: \.(c|cc|cxx|cpp|h|hpp|hxx|m)$
+  description: Formats C, C++, Objective-C and Java code
+  files: \.(c|cc|cxx|cpp|h|hpp|hxx|m|mm|java)$
   language: python
 - id: clang-tidy
   name: clang-tidy
   entry: clang-tidy-hook
-  description: Find warnings/errors in C/CPP code
+  description: Find warnings/errors in C, C++ and Objective-C code
   files: \.(c|cc|cxx|cpp|h|hpp|hxx|m)$
   language: python
 - id: oclint
   name: oclint
   entry: oclint-hook
-  description: Find warnings/errors in C/CPP code
+  description: Find warnings/errors in C, C++ and Objective-C code
   files: \.(c|cc|cxx|cpp|h|hpp|hxx|m)$
   language: python
 - id: uncrustify
   name: uncrustify
   entry: uncrustify-hook
-  description: Formats C/CPP code
-  files: \.(c|cc|cxx|cpp|h|hpp|hxx|m)$
+  description: Formats C, C++, Objective-C, Java, D and Vala code
+  files: \.(c|cc|cxx|cpp|h|hpp|hxx|m|mm|d|java|vala)$
   language: python
 - id: cppcheck
   name: cppcheck
   entry: cppcheck-hook
-  description: Find warnings/errors in C/CPP code
+  description: Find warnings/errors in C, C++ and Objective-C code
   files: \.(c|cc|cxx|cpp|h|hpp|hxx|m)$
   language: python

--- a/README.md
+++ b/README.md
@@ -89,10 +89,10 @@ You can build all of these from source.
 
 | Hook Info                                                                | Type                 | Languages                             |
 | ------------------------------------------------------------------------ | -------------------- | ------------------------------------- |
-| [clang-format](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) | Formatter            | C, C++, ObjC                          |
+| [clang-format](https://clang.llvm.org/docs/ClangFormatStyleOptions.html) | Formatter            | C, C++, ObjC, ObjC++, Java            |
 | [clang-tidy](https://clang.llvm.org/extra/clang-tidy/)                   | Static code analyzer | C, C++, ObjC                          |
 | [oclint](http://oclint.org/)                                             | Static code analyzer | C, C++, ObjC                          |
-| [uncrustify](http://uncrustify.sourceforge.net/)                         | Formatter            | C, C++, C#, ObjC, D, Java, Pawn, VALA |
+| [uncrustify](http://uncrustify.sourceforge.net/)                         | Formatter            | C, C++, C#, ObjC, D, Java, Pawn, Vala |
 | [cppcheck](http://cppcheck.sourceforge.net/)                             | Static code analyzer | C, C++                                |
 
 ### Hook Option Comparison


### PR DESCRIPTION
This also updates the file formats read by the uncrustify hook to match the README.