### PR TITLE
Add a check for a parser error in clang-tidy

### DIFF
--- a/hooks/clang_tidy.py
+++ b/hooks/clang_tidy.py
@@ -24,6 +24,10 @@ class ClangTidyCmd(ClangAnalyzerCmd):
         for filename in self.files:
             self.run_command(filename)
             sys.stdout.buffer.write(self.stdout)
+            # Check to see if the command line arguments were valid
+            if b"error: [CommonOptionsParser]" in self.stderr:
+                sys.stderr.buffer.write(self.stderr)
+                sys.exit(1)
             # The number of warnings depends on errors in system files
             self.stderr = re.sub(b"\d+ warnings and ", b"", self.stderr)
             # Don't output stderr if it's complaining about problems in system files


### PR DESCRIPTION
I spent a while debugging a problem that was just me putting in bad command line arguments (clang tidy accepts `-p compile_commands.json`, but args needs `-p=compile_commands.json`, that's a different problem though). 

This change would just print the error from clang tidy verbatim if that happens.