### PR TITLE
Add support for Include-What-You-Use

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -33,3 +33,9 @@
   description: Find warnings/errors in C/CPP code
   files: \.(c|cc|cxx|cpp|h|hpp|hxx|m)$
   language: python
+- id: include-what-you-use
+  name: include-what-you-use
+  entry: iwyu-hook
+  description: Runs Include-What-You-Use in C/CPP code
+  files: \.(c|cc|cxx|cpp|cu|h|hpp|hxx)$
+  language: python

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,4 +17,5 @@ addons:
     - clang-tidy
     - uncrustify
     - cppcheck
+    - iwyu
 script: "./tests/run_tests.sh"

--- a/hooks/include_what_you_use.py
+++ b/hooks/include_what_you_use.py
@@ -1,0 +1,53 @@
+#! /usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""Wrapper for include-what-you-use"""
+# ==============================================================================
+import shutil
+import sys
+
+from hooks.utils import Command
+
+
+class IncludeWhatYouUseCmd(Command):
+    """Class for the Include-What-You-Use command."""
+
+    command = "include-what-you-use"
+    lookbehind = "include-what-you-use "
+
+    def __init__(self, args):
+        super().__init__(self.command, self.lookbehind, args)
+        self.check_installed()
+        self.parse_args(args)
+
+    def run(self):
+        """Run Include-What-You-Use. Error if diff is incorrect."""
+
+        error_output = []
+        for filename in self.files:
+            self.run_command(filename)
+            error_output.append(self.parse_output())
+
+        if error_output:
+            self.raise_error("Include-What-You-Use violations found\n", "".join(error_output))
+
+    def parse_output(self):
+        """Include-What-You-Use return code is never 0
+        Figure out what it is based on stdout and return that instead
+        """
+        is_correct = "has correct #includes/fwd-decls" in self.stderr
+
+        if not is_correct and self.stderr:
+            output = self.stdout + self.stderr
+            self.stdout = ""
+            self.stderr = ""
+            return output
+        return []
+
+
+def main(argv=None):
+    cmd = IncludeWhatYouUseCmd(argv)
+    cmd.run()
+
+
+if __name__ == "__main__":
+    main()

--- a/setup.cfg
+++ b/setup.cfg
@@ -29,6 +29,7 @@ console_scripts =
     oclint-hook = hooks.oclint:main
     uncrustify-hook = hooks.uncrustify:main
     cppcheck-hook = hooks.cppcheck:main
+    include-what-you-use-hook = hooks.include_what_you_use:main
 
 [options.packages.find]
 exclude =

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -20,14 +20,15 @@ pip_install () {
 }
 
 print_command_versions () {
-  num_cmds="$(command -v cppcheck clang-format oclint uncrustify cppcheck | wc -l)"
-  if [[ ${num_cmds} -ge "4" ]]; then
+  num_cmds="$(command -v cppcheck clang-format oclint uncrustify cppcheck include-what-you-use| wc -l)"
+  if [[ ${num_cmds} -ge "5" ]]; then
     clang-format --version
     clang-tidy --version
     uncrustify --version
     cppcheck --version
+    include-what-you-use --version
   fi
-  if [[ ${num_cmds} -eq "5" ]]; then
+  if [[ ${num_cmds} -eq "6" ]]; then
     oclint --version
   fi
 }
@@ -41,7 +42,7 @@ install_linux_oclint () {
 
 install_linux_cmds () {
   # If these are not already installed
-  apt -y install clang clang-format clang-tidy uncrustify cppcheck
+  apt -y install clang clang-format clang-tidy uncrustify cppcheck iwyu
   install_linux_oclint
 }
 
@@ -50,7 +51,7 @@ install_macos_cmds () {
   if [[ $(command -v brew) && "$(whoami)" == "$(stat /usr/local/var/homebrew | awk '{ print $5 }')" ]]; then
     export HOMEBREW_NO_INSTALL_CLEANUP=1
     export HOMEBREW_NO_AUTO_UPDATE=1
-    brew install llvm uncrustify cppcheck
+    brew install llvm uncrustify cppcheck iwyu
     brew cask install oclint
   else
     echo "Brew not available. Tests may fail."

--- a/tests/test_hooks.py
+++ b/tests/test_hooks.py
@@ -70,6 +70,13 @@ def assert_command_versions(versions):
     cppcheck_versions = ["1.72", "1.82", "1.89", "1.90"]
     compare_versions(cppcheck_versions, versions, "cppcheck")
 
+    # 0.5 on Ubuntu-16.04
+    # 0.9 on Ubuntu-18.04
+    # 0.12 on Ubuntu-20.04
+    # 0.13-0.16 on Macos 10.14/brew
+    iwyu_versions = ["0.5", "0.9", "0.12", "0.13", "0.14", "0.15", "0.16"]
+    compare_versions(iwyu_versions, versions, "include-what-you-use")
+
 
 def set_compilation_db(filenames):
     """Create a compilation database for clang static analyzers."""


### PR DESCRIPTION
I was not able to update all the tests for Include-What-You-Use because I am not sure how to best modify them.

One issue for sure is the fact that IWYU has a peculiar version string output. Example on my Mac:

    $ include-what-you-use --version
    include-what-you-use 0.16 based on clang version 12.0.0

The version number comes after the `include-what-you-use` string, which works nicely with your `lookbehind` logic in the actual hook, but does not play nicely with parts of your testing suite.

Also, the test files you generate for all the other tools are not suitable for IWYU. Here below are two short examples that could do:

Good:
```c++
#include <vector>
void foo(std::vector<int> s) {}
```

Output from IWYU (ran with `include-what-you-use test.hpp`):
```

(include/test.hpp has correct #includes/fwd-decls)
```

Not good:
```c++
#include <string>
#include <vector>
void foo(std::string s) {}
```

Output from IWYU (ran with `include-what-you-use test.hpp`):
```

include/test.hpp should add these lines:

include/test.hpp should remove these lines:
- #include <string>  // lines 1-1

The full include-list for include/test.hpp:
#include <vector>  // for vector
---
```

Closes #28 