### PR TITLE
Fix Cppcheck error message

### DIFF
--- a/hooks/cppcheck.py
+++ b/hooks/cppcheck.py
@@ -28,8 +28,11 @@ class CppcheckCmd(Command):
             self.run_command(filename)
             # Useless error see https://stackoverflow.com/questions/6986033
             useless_error_part = "Cppcheck cannot find all the include files"
-            if useless_error_part in self.stderr:
-                self.stderr = ""
+            err_lines = self.stderr.splitlines(keepends=True)
+            for idx, line in enumerate(err_lines):
+                if useless_error_part in line:
+                    err_lines[idx] = ''
+            self.stderr = ''.join(err_lines)
             if self.returncode != 0:
                 sys.stderr.write(self.stdout + self.stderr)
                 sys.exit(self.returncode)


### PR DESCRIPTION
The version of Cppcheck that I currently have on my machine (2.4.1) seems to output everything to the standard error stream. The current code simply resets that stream if some useless parts are found. 

This PR addresses this by only deleting the lines that match the useless part predicate. Note that this code would fail if the useless line extends over multiple lines.

Fixes #31 