### PR TITLE
Specify dependency on the clang-format Python distribution

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -9,6 +9,7 @@
   description: Formats C, C++, Objective-C, and Java code
   files: \.(c|cc|cxx|cpp|h|hpp|hxx|m|mm|java)$
   language: python
+  additional_dependencies: [clang-format]
 - id: clang-tidy
   name: clang-tidy
   entry: clang-tidy-hook


### PR DESCRIPTION
I have recently reworked the Python distribution of clang-format so that it includes the latest versions of clang-format and builds wheels for a variety of platforms. See these links:

* The repository with the [packaging code](https://github.com/ssciwr/clang-format-wheel)
* The [PyPI package](https://github.com/ssciwr/clang-format-wheel)
* The [list of available platform wheels](https://pypi.org/project/clang-format/#files)

It would be great to have the hook depend on this package.