### PR TITLE
Windows installation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -267,10 +267,10 @@ Use these commands to install some or all of the linters used in this project:
 * MacOS
     * `brew install llvm uncrustify cppcheck include-what-you-use oclint`
 * Windows
-    * `choco install llvm uncrustify cppcheck inlcude-what-you-use`
+    * `choco install llvm uncrustify cppcheck` [4]
 * Cross-platform
     * `pip install cpplint`
-    * `pipx install clang-format` [4]
+    * `pipx install clang-format` [5]
 
 [1]: llvm includes tools like `clang-format` and `clang-tidy`.
 
@@ -281,7 +281,9 @@ Use these commands to install some or all of the linters used in this project:
   binary packages (and zip of source code to compile) for Macos/Linux:
   [releases](https://github.com/oclint/oclint/releases). oclint is not available on windows.
 
-[4]: This will download the latest version. Versions from `10.0.1` and up are supported.
+[4]: To install include-what-you-use on Windows, you need to follow this [guide](https://github.com/include-what-you-use/include-what-you-use) as no include-what-you-use package is available on chocolatey by now.
+
+[5]: This will download the latest version. Versions from `10.0.1` and up are supported.
   To pin to a specific version like `13.0.0`, use `pipx install clang-format==13.0.0`.
   Check out the [clang-format-wheel repository](https://github.com/ssciwr/clang-format-wheel) for information on
   how to download the clang-format binary as part of a CI pre-commit build.

--- a/README.md
+++ b/README.md
@@ -281,7 +281,7 @@ Use these commands to install some or all of the linters used in this project:
   binary packages (and zip of source code to compile) for Macos/Linux:
   [releases](https://github.com/oclint/oclint/releases). oclint is not available on windows.
 
-[4]: To install include-what-you-use on Windows, you need to follow this [guide](https://github.com/include-what-you-use/include-what-you-use) as no include-what-you-use package is available on chocolatey by now.
+[4]: To install include-what-you-use on Windows, you need to follow this [guide](https://github.com/include-what-you-use/include-what-you-use) as no include-what-you-use package is available on chocolatey by now. This [link](https://clang.llvm.org/get_started.html) can also be helpfull.
 
 [5]: This will download the latest version. Versions from `10.0.1` and up are supported.
   To pin to a specific version like `13.0.0`, use `pipx install clang-format==13.0.0`.


### PR DESCRIPTION
In your installation guide for Windows users, it is said to use Chocolatey to install include-what-you-use. It did not work for me and when searching for a solution, I got lead to this issue [#946](https://github.com/include-what-you-use/include-what-you-use/issues/946) : by now, it does not seem to have any include-what-you-use chocolatey package.

I've modified the README.md file to help Windows users to install it easily. It worked for me by following those tutorials :

- [include-what-you-use README.md](https://github.com/include-what-you-use/include-what-you-use/blob/master/README.md)
- [clang get started page](https://clang.llvm.org/get_started.html)