### PR TITLE
Exit cpplint only after checking all files

### DIFF
--- a/hooks/cpplint.py
+++ b/hooks/cpplint.py
@@ -19,9 +19,14 @@ class CpplintCmd(StaticAnalyzerCmd):
 
     def run(self):
         """Run cpplint"""
+        error_occurred = False
         for filename in self.files:
-            self.run_command(self.args + [filename])  # cpplint is unique in requiring args before filename
-            self.exit_on_error()
+            self.run_command_cpplint(self.args + [filename])  # cpplint is unique in requiring args before filename
+            if self.returncode != 0:
+                error_occurred = True
+
+        if error_occurred:
+            sys.exit(1)
 
 
 def main(argv: List[str] = sys.argv):

--- a/hooks/utils.py
+++ b/hooks/utils.py
@@ -143,6 +143,15 @@ class StaticAnalyzerCmd(Command):
         self.stderr += sp_child.stderr
         self.returncode = sp_child.returncode
 
+    def run_command_cpplint(self, args: List[str]):
+        """Run the command and check for errors. Args includes options and filepaths"""
+        args = [self.command, *args]
+        sp_child = sp.run(args, stdout=sp.PIPE, stderr=sp.PIPE)
+        self.returncode = sp_child.returncode
+        
+        if self.returncode != 0:
+            sys.stderr.buffer.write(sp_child.stderr + sp_child.stdout)
+
     def exit_on_error(self):
         if self.returncode != 0:
             sys.stderr.buffer.write(self.stdout + self.stderr)


### PR DESCRIPTION
Currently, cpplint exits immediately after finding an error in a single file. I have changed it so that it completes checking all the files and showing all of the errors rather than exiting on the first problematic file found.

The current design is quite inconvenient because when you have multiple files that could potentially have errors, it will only show you the errors one file at a time. If the errors in all files were showed in one go, they can be corrected in one go, and would avoid the user attempting to commit multiple times until all the files are eventually fixed.