### PR TITLE
Fix oclint output

### DIFF
--- a/hooks/oclint.py
+++ b/hooks/oclint.py
@@ -38,7 +38,7 @@ class OCLintCmd(StaticAnalyzerCmd):
             current_files = os.listdir(os.getcwd())
             self.run_command([filename] + self.args)
             # Errors are sent to stdout instead of stderr
-            if b"Errors" in self.stdout:
+            if b"FilesWithViolations=1" in self.stdout:
                 self.stderr = self.stdout
             # If errors have been captured, stdout is unexpected
             self.stdout = b""


### PR DESCRIPTION
On my version of oclint, I don't see 'Errors', but 'FilesWithViolations=1'.  

Otherwise no output is sent to the console.

Should fix #45 